### PR TITLE
case 110387

### DIFF
--- a/mutators/110387.sh
+++ b/mutators/110387.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Check if a file argument is provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <file> <seed>"
+    exit 1
+fi
+
+file="$1"
+
+sed -i -E 's/arr\[0\]/a/g; s/arr\[1\]/b/g; s/arr\[2\]/c/g; s/arr\[3\]/d/g; s/arr\[4\]/a, b, c, d/g' "$file"


### PR DESCRIPTION
case 110387 involved arr[0]. arr[1]. arr[2]. arr[3], and arr[4] associated with, a ,b, c, d, and a,b,c,d respectively. I searched for the specific instances of arr[] and replaced it with the respective letter.