### PR TITLE
Case 109938

### DIFF
--- a/mutators/109938.sh
+++ b/mutators/109938.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Check if a file argument is provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <file> <seed>"
+    exit 1
+fi
+
+file="$1"
+
+sed -i -E "s/\(__builtin_memcmp\((.*)\) != ([0-9]+)\)/\(__builtin_memcmp\(\1 != \2\)\)/" "$file"


### PR DESCRIPTION
Search for the pattern __builtin_memcmp\((.*)\) != ([0-9]+)\)
Get rid of the parenthesis right before != and place an extra parenthesis after != [0-9]+