### PR TITLE
Case 60718

### DIFF
--- a/mutators/60718.sh
+++ b/mutators/60718.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Check if a file argument is provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <file> <seed>"
+    exit 1
+fi
+
+file="$1"
+
+sed -i -E "s/(void [a-zA-Z_][a-zA-Z0-9_]*\(.*, ... \)) __attribute__\(.*\)([^\)]*)/\1\2/" "$file"

--- a/mutators/60718.sh
+++ b/mutators/60718.sh
@@ -8,4 +8,4 @@ fi
 
 file="$1"
 
-sed -i -E "s/(void [a-zA-Z_][a-zA-Z0-9_]*\(.*, ... \)) __attribute__\(.*\)([^\)]*)/\1\2/" "$file"
+sed -i -E "s/__attribute__\(\(format\(.*, [0-9]+, [0-9]+\)\)\)//" "$file"


### PR DESCRIPTION
I had to change the input file so that . . . ) __attribute__((format(printf, 3, 4))); is in the same line as the method header
Looks for the pattern void <method name> (.*, . . . ) __attribute__(.*)
and remove the __attribute__(.*) part